### PR TITLE
Remove copy as it's unneded and errors out

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,6 @@
   unarchive: 
     src: "{{__crashplan_dl_filename}}" 
     dest: "{{__crashplan_dl_path}}"
-    copy: no
     remote_src: yes
   when: cp_installed.stat.exists == False
 


### PR DESCRIPTION
```
FAILED! => {"changed": false, "failed": true, "msg": "parameters are mutually exclusive: ('copy', 'remote_src')"}
```